### PR TITLE
Fix code scanning alert no. 1: Missing regular expression anchor

### DIFF
--- a/src/rewrite.ts
+++ b/src/rewrite.ts
@@ -1,5 +1,5 @@
 const rewrites: [RegExp, string][] = [
-  [/instagram.com\/reels\//i, 'instagram.com/reel/'],
+  [/^instagram.com\/reels\/$/i, 'instagram.com/reel/'],
 ];
 
 export default function rewrite(content: string) {


### PR DESCRIPTION
Fixes [https://github.com/RooRay/MediaHelper/security/code-scanning/1](https://github.com/RooRay/MediaHelper/security/code-scanning/1)

To fix the problem, we need to add anchors to the regular expression to ensure it matches the pattern at the expected locations. Specifically, we should add the `^` anchor at the beginning to match the start of the string and the `$` anchor at the end to match the end of the string. This will ensure that the regular expression only matches the exact pattern `instagram.com/reels/` and not any arbitrary hosts or paths before or after it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
